### PR TITLE
In epubs, use Navigation Title for page titles if it exists

### DIFF
--- a/modules/osci_tk_epub/templates/node__epub.tpl.php
+++ b/modules/osci_tk_epub/templates/node__epub.tpl.php
@@ -1,12 +1,24 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml"
-	  xmlns:epub="http://www.idpf.org/2007/ops">
+         xmlns:epub="http://www.idpf.org/2007/ops">
 <head>
-	<meta name="robots" content="noindex" />
-	<title><?php print $title; ?></title>
-	<?php print drupal_get_css(); ?>
+       <meta name="robots" content="noindex" />
+       <title>
+         <?php
+         $navTitle = null;
+         if (is_array($node->field_navigation_title) && !empty($node->field_navigation_title)) {
+             foreach ($node->field_navigation_title as $field_language => $delta_array) {
+                 foreach ($delta_array as $index => $value) {
+                     $navTitle = strip_tags($value['value']);
+                 }
+             }
+         }
+         print $navTitle ? $navTitle : $title;
+         ?>
+       </title>
+       <?php print drupal_get_css(); ?>
 </head>
 <body class="<?php print $classes; ?> node-<?php print $node->nid; ?>">
-	<?php print drupal_render($content); ?>
+       <?php print drupal_render($content); ?>
 </body>
 </html>


### PR DESCRIPTION
This commit aligns the section titles in the epubs and print formats with what is displayed to the end user in the UI.  This is meant to make these section titles readable in OSCI as well as in the Data Hub where we use this title to describe the section name.